### PR TITLE
Log all output as JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - tip
   - 1.7
+  - 1.7.1
 
 notifications:
     email: false


### PR DESCRIPTION
Use jsonapi.org structures for errors and success.
