### PR TITLE
Remove travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-
-go:
-  - tip
-  - 1.7
-  - 1.7.1
-
-notifications:
-    email: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/jabley/httptraced.svg?branch=master)](https://travis-ci.org/jabley/httptraced)
+![Build Status](https://github.com/jabley/httptraced/actions/workflows/go.yml/badge.svg)
 
 Tool to monitor connection latency.
 


### PR DESCRIPTION
Build status badge can use new GitHub Actions integration.

I've not used travis for years and I'm not concerned about GitHub lock-in here.